### PR TITLE
Fix rcut trimming bug

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -807,7 +807,10 @@ export function rcut(text: string, n: number, suffix = ''): string {
 		return result;
 	}
 
-	return result.trim().replace(/b$/, '') + suffix;
+       // Removing the trailing word boundary accidentally removed any trailing
+       // letter "b" from the result. Trim the right side only and append the
+       // suffix.
+       return result.trimEnd() + suffix;
 }
 
 // Defacto standard: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -155,14 +155,16 @@ suite('Strings', () => {
 		assert.strictEqual(strings.lcut('............a', 10, '…'), '............a');
 	});
 
-	suite('rcut', () => {
-		test('basic truncation', () => {
-			assert.strictEqual(strings.rcut('foo bar', 0), 'foo');
-			assert.strictEqual(strings.rcut('foo bar', 1), 'foo');
-			assert.strictEqual(strings.rcut('foo bar', 4), 'foo');
-			assert.strictEqual(strings.rcut('foo bar', 7), 'foo bar');
-			assert.strictEqual(strings.rcut('test string 0.1.2.3', 3), 'test');
-		});
+        suite('rcut', () => {
+                test('basic truncation', () => {
+                        assert.strictEqual(strings.rcut('foo bar', 0), 'foo');
+                        assert.strictEqual(strings.rcut('foo bar', 1), 'foo');
+                        assert.strictEqual(strings.rcut('foo bar', 4), 'foo');
+                        assert.strictEqual(strings.rcut('foo bar', 7), 'foo bar');
+                        assert.strictEqual(strings.rcut('test string 0.1.2.3', 3), 'test');
+                        // Regression test for trimming bug when result ends with 'b'
+                        assert.strictEqual(strings.rcut('abbb bc', 0), 'abbb');
+                });
 
 		test('truncation with suffix', () => {
 			assert.strictEqual(strings.rcut('foo bar', 0, '…'), 'foo…');


### PR DESCRIPTION
## Summary
- fix unintended character removal in `rcut`
- add regression test for `rcut` trimming bug